### PR TITLE
Add rockspec

### DIFF
--- a/lua-schema-scm-1.rockspec
+++ b/lua-schema-scm-1.rockspec
@@ -1,0 +1,24 @@
+package = "lua-schema"
+version = "scm-1"
+source = {
+   url = "git://github.com/sschoener/lua-schema"
+}
+description = {
+   summary = "A simple package to check Lua-data against schemata.",
+   detailed = [[
+      A simple package to check Lua-data against schemata. The package is written
+      entirely in Lua (5.2) and has no further dependencies. It is designed to be
+      easily extensible.
+   ]],
+   homepage = "http://github.com/sschoener/lua-schema",
+   license = "MIT/X11"
+}
+dependencies = {
+   "lua >= 5.2",
+}
+build = {
+   type = "builtin",
+   modules = {
+      schema = "schema.lua"
+   }
+}


### PR DESCRIPTION
This PR adds a LuaRocks rockspec to the repository.

I also suggest creating an account at https://luarocks.org and uploading lua-schema there. This can be done from the command line (`luarocks upload lua-schema-scm-1.rockspec`) or via the web interface. 

Being an "scm" (source control manager) rockspec it means it will download the latest code from Github, but users will have to type `luarocks install lua-schema --server=https://luarocks.org/dev` to get it. It would be even nicer to have a numbered release in the stable LuaRocks repository! To do this:
1. Copy `lua-schema-scm-1.rockspec` to `lua-schema-0.1-1.rockspec` (`-1` is the rockspec revision)
2. Make a release tag in the repo: `git tag v0.1; git push --tags`
3. Edit  `lua-schema-0.1-1.rockspec`:
   - bump the version: `version = "0.1-1"` (must match the filename)
   - and add `source.tag = "v0.1"` 
4. Run `luarocks upload lua-schema-0.1-1.rockspec` or use the web interface
   - `luarocks upload` is preferred because it automatically creates a `lua-schema-0.1-1.src.rock` file which serves as a cache of the sources in the luarocks.org server.

Thank you!!
