### PR TITLE
Add Pattern(patt) for matching Lua string patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,22 @@ The following schemata are built into the package (sorted alphabetically):
       -- No suitable alternative: No schema matches '<val>'
       print(schema.CheckSchema(negExample, exampleSchema))
 
+* **Pattern(patt)**
+
+  Checks that the value is a string matching a given Lua pattern.
+  The entire string must match the pattern: if `^` and `$` markers
+  in the beginning and end of string are not present, they are
+  internally added to the pattern.
+  Example:
+
+      local exampleSchema = schema.Pattern("[A-Za-z_][A-Za-z0-9_]*")
+      local posExample = "test"
+      local posExample2 = "_"
+
+      local negExample = "0var"
+      -- Invalid value: '<val>' must match pattern '[A-Za-z_][A-Za-z0-9_]*'
+      print(schema.CheckSchema(negExample, exampleSchema))
+
 * **Record(tableSchema, additionalValues = false)**
   
   Takes a table schema. The table schema consists of keys (strings only) and 

--- a/schema.lua
+++ b/schema.lua
@@ -263,6 +263,29 @@ function schema.String  (obj, path) return TypeSchema(obj, path, "string")   end
 function schema.Table   (obj, path) return TypeSchema(obj, path, "table")    end
 function schema.UserData(obj, path) return TypeSchema(obj, path, "userdata") end
 
+-- Checks that some value is a string matching a given pattern.
+function schema.Pattern(pattern)
+    local userPattern = pattern
+    if not pattern:match("^^") then
+        pattern = "^" .. pattern
+    end
+    if not pattern:match("$$") then
+        pattern = pattern .. "$"
+    end
+    local function CheckPattern(obj, path)
+        local err = schema.String(obj, path)
+        if err then
+            return err
+        end
+        if string.match(obj, pattern) then
+            return nil
+        else
+            return schema.Error("Invalid value: '"..path.."' must match pattern '"..userPattern.."'", path)
+        end
+    end
+    return CheckPattern
+end
+
 -- Checks that some number is an integer.
 function schema.Integer(obj, path)
     local err = schema.Number(obj, path)


### PR DESCRIPTION
Note: I considered adding an optional second argument `[, msg]` for providing friendlier error messages than exposing the Lua pattern. I can add it to this PR if you like the idea!

Documentation added to README.md:

**Pattern(patt)**

Checks that the value is a string matching a given Lua pattern.
The entire string must match the pattern: if `^` and `$` markers
in the beginning and end of string are not present, they are
internally added to the pattern.
Example:

```
 local exampleSchema = schema.Pattern("[A-Za-z_][A-Za-z0-9_]*")
 local posExample = "test"
 local posExample2 = "_"

 local negExample = "0var"
 -- Invalid value: '<val>' must match pattern '[A-Za-z_][A-Za-z0-9_]*'
 print(schema.CheckSchema(negExample, exampleSchema))
```
