### PR TITLE
Added MixedTable check

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We read a bunch of tables, each of them looks like this:
         id        = 12, -- id is a number
         usertype  = "admin", -- one of 'admin', 'moderator', 'user'
         nicknames = { "Nick1", "Nick2" }, -- nicknames used by this user
-        rights    = { 4, 1, 7} -- table of fixed length of types
+        rights    = { 4, 1, 7 } -- table of fixed length of types
     }
 
 A schema describing such a table would be


### PR DESCRIPTION
MixedTable check is quiet similar to Record with following differences:
1. Allow keys with `number` type in addition to `string` type
sample usage:
```Lua
local schema = require('schema')

local t = {
        [1] = 4,
        [2] = 5,
        count = 2,
}

local t_schema = schema.MixedTable {
        count = schema.Number,
        [1] = schema.Number,
        [2] = schema.Number,
}

local err = schema.CheckSchema(t, t_schema)
if err then error(err) end
```
2. Allow checking generated schematas via `__index` metamethod:
sample usage:
```Lua
local schema = require('schema')

local t = { name = 'abc',
{ args = { min = 1, max = 1, assume = { 'number' } }, function() end },
{ args = { min = 1, max = 1, assume = { 'value' } }, function() end },
{ args = { }, function () end }
}

local t_schema_mt = {
        __index = function(_, key)
                if type(key) ~= 'number' or math.floor(key) ~= key then
                        return
                end

                return schema.MixedTable {
                        args = schema.Record {
                                min = schema.Optional(schema.Number),
                                max = schema.Optional(schema.Number),
                                assume = schema.Optional(schema.Collection(schema.String)),
                        },
                        [1] = schema.Function,
                }
        end
}

local t_schema = schema.MixedTable(setmetatable({
        name = schema.String,
}, t_schema_mt))

local err = schema.CheckSchema(t, t_schema)
if err then error(err) end
```